### PR TITLE
Add content edges and a terminal query surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 grf
+grafux
 grf.exe
 grf.darwin
 *.o
@@ -48,4 +49,6 @@ yarn.lock
 
 # Project-specific
 .grafux.yml.local
+# Generated graph artifact. Delete this line to commit it as a shared map.
+.grafux/
 CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,11 @@
 Grafux is a lightweight CLI tool that scans a file directory and visualizes it as an interactive force-directed graph in the browser. Think Obsidian's graph view, but for any directory on your filesystem.
 
 **Command:** `grf`
-**Usage:** Run `grf` in any directory → scans files/folders → opens localhost in default browser → renders an interactive node graph
+**Usage:** Run `grf` in any directory → scans files/folders → reads imports and links inside those files → opens localhost in default browser → renders an interactive node graph
+
+The same graph is written to `.grafux/graph.json` and is queryable from the
+terminal (`grf query`, `grf explain`, `grf neighbors`, `grf path`), so agents can
+traverse the project instead of grepping it.
 
 ## Tech Stack
 
@@ -69,8 +73,19 @@ go run . /path/to/project --port 8080 --no-open
 
 ```
 grafux/
-├── main.go                  # CLI entry point
-├── scanner/scanner.go       # filepath.Walk → nodes + edges
+├── main.go                  # CLI entry point: verb dispatch, flags, server, browser
+├── cli/cli.go               # scan / query / explain / neighbors / path
+├── config/config.go         # .grafux.yml + flag precedence
+├── scanner/scanner.go       # filepath.Walk → nodes + structural edges
+├── extract/                 # content edges — relationships inside files
+│   ├── extract.go           # Extractor interface, the content pass, Stats
+│   ├── resolve.go           # specifier → node ID, with extracted/inferred confidence
+│   ├── golang.go            # go/parser imports, resolved through go.mod
+│   ├── jsts.go              # JS/TS relative imports, require(), dynamic import()
+│   ├── python.go            # absolute and relative (dotted) imports
+│   └── markdown.go          # [[wikilinks]] and [text](relative/path)
+├── query/query.go           # fuzzy node resolution, search, BFS traversal, explain
+├── store/store.go           # .grafux/graph.json — atomic write, upward Find
 ├── server/
 │   ├── server.go            # HTTP server + go:embed
 │   └── web/
@@ -81,7 +96,9 @@ grafux/
 └── CLAUDE.md
 ```
 
-**Dependencies:** Go stdlib only. d3 v7 loaded from CDN at runtime.
+**Dependencies:** Go stdlib + gopkg.in/yaml.v3 (config only). d3 v7 from CDN at
+runtime. Every parser is pure Go — no cgo, so cross-compilation stays a plain
+`GOOS=… go build`.
 
 ## Core Concepts
 
@@ -102,7 +119,26 @@ grafux/
 
 **Structural edges (MVP):** Every file connects to its parent folder. Every subfolder connects to its parent folder. This creates a tree structure at minimum.
 
-**Content edges (v2):** For markdown files, parse `[[wikilinks]]` and `[text](relative-path.md)` to create cross-links between files. These show up as non-hierarchical connections in the graph.
+**Content edges (implemented):** Relationships read out of file contents rather
+than the directory tree. `import` edges come from Go, JS/TS, and Python imports;
+`reference` edges from markdown `[[wikilinks]]` and `[text](relative-path.md)`.
+They render in a distinct color on top of the structural tree and can be toggled
+off in the settings panel.
+
+Only references resolving to a node inside the scan become edges — third-party
+packages and external URLs are dropped. Go imports resolve to the *package
+directory*, which is what a Go import actually names.
+
+Each content edge carries a `confidence`:
+
+| Value       | Meaning                                                        |
+| ----------- | -------------------------------------------------------------- |
+| `extracted` | Exactly one candidate matched — the source named its target     |
+| `inferred`  | Several candidates matched and the resolver picked one          |
+
+**Adding a language:** implement `extract.Extractor` (return the extensions you
+handle, and a `Ref` per reference with the `Strategy` that resolves it), then
+register it in the `extractors` slice in `extract/extract.go`.
 
 ### Force-Directed Layout
 
@@ -150,6 +186,29 @@ grf --include "*.md"   # Only show specific file types
 grf --exclude "*.log"  # Exclude specific file types
 ```
 
+### Commands (no browser)
+
+A first argument matching a known verb dispatches to `cli` instead of starting
+the server. Everything else is treated as a path to visualize, so bare `grf` and
+`grf ./some/dir` behave exactly as before.
+
+```bash
+grf scan [path]                    # scan and write .grafux/graph.json
+grf query <terms...>               # rank nodes; every term must match
+grf explain <node>                 # a node, its parent, and every link in and out
+grf neighbors <node> --hops 2      # walk outward; --content skips the folder tree
+grf path <from> <to>               # shortest connection, edges treated as undirected
+```
+
+Shared flags: `--json` for machine-readable output, `--graph PATH` to read a
+specific artifact, `--rescan` to ignore the saved one. Node arguments resolve
+fuzzily (exact ID → path suffix → base name → ranked search); an ambiguous name
+returns the candidate list rather than guessing.
+
+Commands find the graph the way git finds `.git` — walking up from the working
+directory. With no artifact anywhere, they scan the current directory and say so
+on stderr.
+
 ## Default Ignore List
 
 These are excluded from scanning by default (overridable via flags):
@@ -167,6 +226,8 @@ These are excluded from scanning by default (overridable via flags):
 ### `GET /api/graph`
 
 Returns the full graph data as JSON.
+
+The graph served here is identical to the one written to `.grafux/graph.json`.
 
 ```json
 {
@@ -194,6 +255,13 @@ Returns the full graph data as JSON.
       "source": "src",
       "target": "src/main.go",
       "type": "structural"
+    },
+    {
+      "source": "src/main.go",
+      "target": "src/auth",
+      "type": "import",
+      "confidence": "extracted",
+      "line": 7
     }
   ],
   "meta": {
@@ -201,6 +269,7 @@ Returns the full graph data as JSON.
     "totalFiles": 42,
     "totalFolders": 8,
     "scanDepth": 5,
+    "contentEdges": 63,
     "scannedAt": "2026-03-04T12:00:00Z"
   }
 }
@@ -225,12 +294,23 @@ Returns the full graph data as JSON.
 
 ### v0.2 — Content Awareness
 
-- [ ] Parse markdown `[[wikilinks]]` and `[text](path)` links
-- [ ] Show content-based edges as a different color/style
-- [ ] Filter: toggle structural vs content edges
+- [x] Parse markdown `[[wikilinks]]` and `[text](path)` links
+- [x] Parse Go, JS/TS, and Python imports
+- [x] Show content-based edges as a different color/style
+- [x] Filter: toggle structural vs content edges
+- [x] Persist the graph to `.grafux/graph.json`
+- [x] `query` / `explain` / `neighbors` / `path` commands with `--json`
 - [ ] Color nodes by file extension/type
 
-### v0.3 — Interactivity
+### v0.3 — Agent Surface
+
+- [ ] MCP stdio server (`grf mcp`) exposing query/path/explain as tools
+- [ ] Token-budgeted context packs (`grf context <node> --budget N`)
+- [ ] Hub ranking (degree/PageRank) and community detection
+- [ ] Symbol-level nodes (functions, types) rather than file-level only
+- [ ] Watch mode: rewrite `graph.json` as files change
+
+### v0.3b — Interactivity
 
 - [ ] Search/filter nodes by name or extension
 - [ ] Click node to open file info panel (size, modified date, connections)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # grafux
 
-**Obsidian's graph view, for any directory on your filesystem.**
+**Obsidian's graph view, for any directory on your filesystem — readable by you and by your agent.**
 
-Run `grf` in any folder → it scans the file tree, starts a localhost server, and opens an interactive force-directed graph in your browser. Files are nodes. Folders are hubs. Everything is physics.
+Run `grf` in any folder → it scans the file tree, reads the imports and links *inside* your files, starts a localhost server, and opens an interactive force-directed graph in your browser. Files are nodes. Folders are hubs. Everything is physics.
+
+The same graph is written to `.grafux/graph.json` and queryable from the terminal, so an agent can traverse your project's dependencies instead of grepping for them.
 
 ---
 
@@ -37,6 +39,31 @@ grf /path/to/project
 grf --depth 3
 ```
 
+### Querying the graph
+
+Every run writes `.grafux/graph.json`. These commands read it — no server, no browser:
+
+```bash
+grf scan                              # scan and save the graph
+grf query auth token                  # find nodes; every term must match
+grf explain scanner/scanner.go        # one node and everything it connects to
+grf neighbors main.go --content       # what it reaches, ignoring the folder tree
+grf path docs/design.md policy.py     # shortest connection between two things
+```
+
+Any command takes `--json` for machine-readable output, and node arguments are
+fuzzy: `grf explain token.go` resolves to `auth/token.go`, and an ambiguous name
+returns the candidates rather than guessing.
+
+```
+$ grf path docs/design.md policy.py
+docs/design.md → pkg/auth/policy.py (2 hop(s))
+
+  docs/design.md
+    --[reference extracted L3]-->  docs/auth-notes.md
+    --[reference extracted L2]-->  pkg/auth/policy.py
+```
+
 ### Flags
 
 | Flag            | Default | Description                                   |
@@ -45,6 +72,9 @@ grf --depth 3
 | `--port N`      | random  | Port to serve on                              |
 | `--no-open`     | false   | Don't auto-open the browser                   |
 | `--show-hidden` | false   | Include dotfiles and hidden folders           |
+| `--include`     | —       | Comma-separated extensions to include only    |
+| `--exclude`     | —       | Comma-separated extensions to drop            |
+| `--theme NAME`  | gruvbox | `gruvbox`, `obsidian`, `forest`, `aurora`, `mono` |
 
 ---
 
@@ -54,10 +84,37 @@ grf --depth 3
 grf invoked
   → scans directory tree (respects --depth, ignores .git / node_modules / etc.)
   → builds a graph: files + folders as nodes, parent relationships as edges
+  → reads each parseable file and adds content edges (imports, links)
+  → writes .grafux/graph.json
   → starts a local HTTP server
   → opens your default browser
   → renders an interactive force-directed graph on HTML5 Canvas
 ```
+
+**Edge types:**
+
+| Type         | Meaning                                                     | Drawn as              |
+| ------------ | ----------------------------------------------------------- | --------------------- |
+| `structural` | The directory tree — a file's parent folder                 | Faint, underneath     |
+| `import`     | A Go/JS/TS/Python import that resolves inside the project    | Bright, on top        |
+| `reference`  | A markdown `[[wikilink]]` or `[text](relative/path)`         | Bright, on top        |
+
+Every content edge carries a confidence: **extracted** when the source named its
+target unambiguously, **inferred** when several candidates matched and the
+resolver had to pick one. Toggle content edges on and off in the settings panel.
+
+**What gets parsed:**
+
+| Language        | Extensions                                              | How                             |
+| --------------- | ------------------------------------------------------- | ------------------------------- |
+| Go              | `.go`                                                    | `go/parser`, resolved via `go.mod` |
+| JavaScript / TS | `.js .jsx .mjs .cjs .ts .tsx .mts .cts .vue .svelte .astro` | relative specifiers only     |
+| Python          | `.py .pyi`                                               | absolute and relative imports   |
+| Markdown        | `.md .mdx .markdown`                                     | wikilinks and inline links      |
+
+Only references that resolve to a file in the scan become edges — third-party
+packages and external URLs are left out. Code inside fenced blocks and
+commented-out imports are ignored.
 
 **Node types:**
 
@@ -88,8 +145,8 @@ grf invoked
 ## Roadmap
 
 - [x] **v0.1** — Directory scan, force-directed graph, dark theme, drag/zoom/pan, hover highlights, auto-open browser
-- [ ] **v0.2** — Parse markdown `[[wikilinks]]` and `[links](path)` for content-based edges
-- [ ] **v0.3** — Search/filter nodes, click to open file info panel, minimap
+- [x] **v0.2** — Content edges from Go/JS/TS/Python imports and markdown links, persisted `graph.json`, `query`/`explain`/`neighbors`/`path` commands
+- [ ] **v0.3** — MCP server, token-budgeted context packs, hub and community detection, symbol-level nodes
 - [ ] **v0.4** — Spanning tree overlays, layout algorithm selection, physics settings panel
 - [ ] **v0.5** — WebGL rendering for 10k+ node graphs, watch mode (live filesystem updates), PNG/SVG export
 
@@ -103,8 +160,15 @@ go run . [flags] [path]
 
 # Project layout
 grafux/
-├── main.go                  # CLI: flags, scanner, server, browser open
-├── scanner/scanner.go       # filepath.Walk → nodes + edges JSON
+├── main.go                  # CLI: verb dispatch, flags, scanner, server, browser open
+├── cli/cli.go               # scan / query / explain / neighbors / path
+├── scanner/scanner.go       # filepath.Walk → nodes + structural edges
+├── extract/                 # content edges: imports and links inside files
+│   ├── extract.go           # extractor interface + the content pass
+│   ├── resolve.go           # specifier → node ID, with confidence
+│   └── golang.go, jsts.go, python.go, markdown.go
+├── query/query.go           # search, traversal, shortest path, explain
+├── store/store.go           # .grafux/graph.json read + atomic write
 ├── server/
 │   ├── server.go            # HTTP server + go:embed
 │   └── web/

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,520 @@
+// Package cli implements grafux's non-visual commands — the surface an agent
+// or a script uses. Running `grf` with no verb still opens the browser; the
+// verbs here read the same graph without one.
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"grafux/config"
+	"grafux/extract"
+	"grafux/query"
+	"grafux/scanner"
+	"grafux/store"
+)
+
+// commands maps a verb to its implementation.
+var commands = map[string]func([]string) error{
+	"scan":      cmdScan,
+	"query":     cmdQuery,
+	"path":      cmdPath,
+	"neighbors": cmdNeighbors,
+	"explain":   cmdExplain,
+}
+
+// IsCommand reports whether name is a verb rather than a path to visualize.
+func IsCommand(name string) bool {
+	_, ok := commands[name]
+	return ok
+}
+
+// Run dispatches a verb.
+func Run(name string, args []string) error {
+	fn, ok := commands[name]
+	if !ok {
+		return fmt.Errorf("unknown command %q", name)
+	}
+	return fn(args)
+}
+
+// Usage describes the verbs, for the top-level help text.
+func Usage() string {
+	return `Commands:
+  grf scan [path]              Scan and write .grafux/graph.json
+  grf query <terms...>         Find nodes by name, path, or extension
+  grf explain <node>           Show one node and everything it connects to
+  grf neighbors <node>         List what a node reaches, with --hops N
+  grf path <from> <to>         Trace the shortest connection between two nodes
+
+Run a command with -h for its own flags.`
+}
+
+// BuildGraph scans a directory and enriches it with content edges. It is the
+// one place that defines what a complete grafux graph is.
+func BuildGraph(root string, cfg config.Config) (*scanner.Graph, extract.Stats, error) {
+	g, err := scanner.Scan(root, scanner.Options{
+		MaxDepth:   cfg.Depth,
+		ShowHidden: cfg.ShowHidden,
+		Include:    cfg.Include,
+		Exclude:    cfg.Exclude,
+	})
+	if err != nil {
+		return nil, extract.Stats{}, err
+	}
+	return g, extract.Run(g), nil
+}
+
+// ─── Shared flags and loading ────────────────────────────────────────────────
+
+type commonFlags struct {
+	graphPath string
+	rescan    bool
+	asJSON    bool
+}
+
+func (c *commonFlags) register(fs *flag.FlagSet) {
+	fs.StringVar(&c.graphPath, "graph", "", "Path to a graph.json (default: nearest .grafux/graph.json)")
+	fs.BoolVar(&c.rescan, "rescan", false, "Scan the current directory instead of reading a saved graph")
+	fs.BoolVar(&c.asJSON, "json", false, "Emit JSON instead of text")
+}
+
+// load returns a query-ready graph, preferring a saved artifact and falling
+// back to scanning the working directory so the commands work before anyone
+// has run `grf scan`.
+func (c *commonFlags) load() (*query.Graph, error) {
+	if c.rescan {
+		return c.scanHere()
+	}
+	if c.graphPath != "" {
+		g, err := store.Load(c.graphPath)
+		if err != nil {
+			return nil, err
+		}
+		return query.New(g), nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	path, _, err := store.Find(cwd)
+	if err == nil {
+		g, loadErr := store.Load(path)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		return query.New(g), nil
+	}
+	if err != store.ErrNotFound {
+		return nil, err
+	}
+	fmt.Fprintln(os.Stderr, "note: no .grafux/graph.json found — scanning this directory. Run `grf scan` to save one.")
+	return c.scanHere()
+}
+
+func (c *commonFlags) scanHere() (*query.Graph, error) {
+	cfg, err := config.Load(".")
+	if err != nil {
+		return nil, err
+	}
+	g, _, err := BuildGraph(".", cfg)
+	if err != nil {
+		return nil, err
+	}
+	return query.New(g), nil
+}
+
+// parseArgs parses flags wherever they appear — before, after, or between
+// positional arguments. Go's flag package stops at the first non-flag, which
+// would silently swallow `grf neighbors main.go --content` as one long name.
+func parseArgs(fs *flag.FlagSet, args []string) ([]string, error) {
+	var positional []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		rest := fs.Args()
+		if len(rest) == 0 {
+			return positional, nil
+		}
+		positional = append(positional, rest[0])
+		args = rest[1:]
+	}
+}
+
+func emitJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// ─── scan ────────────────────────────────────────────────────────────────────
+
+func cmdScan(args []string) error {
+	fs := flag.NewFlagSet("scan", flag.ExitOnError)
+	depth := fs.Int("depth", 0, "Max directory depth (0 = use config default)")
+	showHidden := fs.Bool("show-hidden", false, "Include hidden files and folders")
+	include := fs.String("include", "", "Comma-separated extensions to include")
+	exclude := fs.String("exclude", "", "Comma-separated extensions to exclude")
+	out := fs.String("out", "", "Write the graph here instead of <path>/.grafux/graph.json")
+	quiet := fs.Bool("quiet", false, "Only print the path that was written")
+	rest, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+
+	root := "."
+	if len(rest) > 0 {
+		root = rest[0]
+	}
+
+	cfg, cfgErr := config.Load(root)
+	if cfgErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load .grafux.yml: %v\n", cfgErr)
+	}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "depth":
+			cfg.Depth = *depth
+		case "show-hidden":
+			cfg.ShowHidden = *showHidden
+		case "include":
+			cfg.Include = splitList(*include)
+		case "exclude":
+			cfg.Exclude = splitList(*exclude)
+		}
+	})
+
+	g, stats, err := BuildGraph(root, cfg)
+	if err != nil {
+		return err
+	}
+
+	written, err := saveTo(root, *out, g)
+	if err != nil {
+		return err
+	}
+
+	if *quiet {
+		fmt.Println(written)
+		return nil
+	}
+	fmt.Printf("%s\n", g.Meta.Root)
+	fmt.Printf("  %d files · %d folders · %d structural edges · %d content edges\n",
+		g.Meta.TotalFiles, g.Meta.TotalFolders, len(g.Edges)-stats.Resolved, stats.Resolved)
+	fmt.Printf("  read %d parseable files, resolved %d of %d references",
+		stats.FilesRead, stats.Resolved+stats.Duplicate, stats.Refs)
+	if stats.Duplicate > 0 {
+		fmt.Printf(" (%d duplicate)", stats.Duplicate)
+	}
+	fmt.Println()
+	fmt.Printf("  wrote %s\n", written)
+	return nil
+}
+
+func saveTo(root, out string, g *scanner.Graph) (string, error) {
+	if out == "" {
+		return store.Save(root, g)
+	}
+	data, err := json.MarshalIndent(g, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if out == "-" {
+		_, err = os.Stdout.Write(append(data, '\n'))
+		return "(stdout)", err
+	}
+	return out, os.WriteFile(out, data, 0o644)
+}
+
+func splitList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// ─── query ───────────────────────────────────────────────────────────────────
+
+func cmdQuery(args []string) error {
+	fs := flag.NewFlagSet("query", flag.ExitOnError)
+	var cf commonFlags
+	cf.register(fs)
+	limit := fs.Int("limit", 20, "Maximum results")
+	rest, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) == 0 {
+		return fmt.Errorf("usage: grf query <terms...>")
+	}
+	term := strings.Join(rest, " ")
+
+	g, err := cf.load()
+	if err != nil {
+		return err
+	}
+	matches := query.Search(g, term, *limit)
+
+	if cf.asJSON {
+		return emitJSON(map[string]any{
+			"query":   term,
+			"root":    g.Meta.Root,
+			"matches": matches,
+		})
+	}
+
+	w := os.Stdout
+	writeHeader(w, g)
+	if len(matches) == 0 {
+		fmt.Fprintf(w, "\nno match for %q\n", term)
+		return nil
+	}
+	fmt.Fprintf(w, "\n%d match(es) for %q:\n\n", len(matches), term)
+	width := 0
+	for _, m := range matches {
+		if len(m.Node.ID) > width {
+			width = len(m.Node.ID)
+		}
+	}
+	for _, m := range matches {
+		kind := m.Node.Type
+		if m.Node.Extension != "" {
+			kind = m.Node.Extension
+		}
+		fmt.Fprintf(w, "  %-*s  %-8s  %d link(s)\n", width, m.Node.ID, kind, m.Degree)
+	}
+	return nil
+}
+
+// ─── explain ─────────────────────────────────────────────────────────────────
+
+func cmdExplain(args []string) error {
+	fs := flag.NewFlagSet("explain", flag.ExitOnError)
+	var cf commonFlags
+	cf.register(fs)
+	rest, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return fmt.Errorf("usage: grf explain <node>")
+	}
+
+	g, err := cf.load()
+	if err != nil {
+		return err
+	}
+	node, err := g.Resolve(rest[0])
+	if err != nil {
+		return err
+	}
+	ex, _ := query.Explain(g, node.ID)
+
+	if cf.asJSON {
+		return emitJSON(ex)
+	}
+
+	w := os.Stdout
+	fmt.Fprintf(w, "%s\n", ex.Node.ID)
+	fmt.Fprintf(w, "  type      %s%s\n", ex.Node.Type, extNote(ex.Node))
+	fmt.Fprintf(w, "  path      %s\n", ex.Node.Path)
+	if ex.Parent != "" {
+		fmt.Fprintf(w, "  parent    %s\n", ex.Parent)
+	}
+	fmt.Fprintf(w, "  links     %d\n", ex.Degree)
+
+	writeLinks(w, "depends on", ex.DependsOn)
+	writeLinks(w, "depended on by", ex.DependedOn)
+	if len(ex.Children) > 0 {
+		writeLinks(w, "contains", ex.Children)
+	}
+	return nil
+}
+
+func extNote(n scanner.Node) string {
+	if n.Extension == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (%s, %s)", n.Extension, humanSize(n.Size))
+}
+
+func humanSize(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGT"[exp])
+}
+
+func writeLinks(w io.Writer, title string, links []query.Link) {
+	fmt.Fprintf(w, "\n%s (%d)\n", title, len(links))
+	if len(links) == 0 {
+		return
+	}
+	width := 0
+	for _, l := range links {
+		if len(l.ID) > width {
+			width = len(l.ID)
+		}
+	}
+	for _, l := range links {
+		fmt.Fprintf(w, "  %-*s  %s", width, l.ID, l.Type)
+		if l.Confidence != "" {
+			fmt.Fprintf(w, "  [%s]", l.Confidence)
+		}
+		if l.Line > 0 {
+			fmt.Fprintf(w, "  L%d", l.Line)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// ─── neighbors ───────────────────────────────────────────────────────────────
+
+func cmdNeighbors(args []string) error {
+	fs := flag.NewFlagSet("neighbors", flag.ExitOnError)
+	var cf commonFlags
+	cf.register(fs)
+	hops := fs.Int("hops", 1, "How many hops to walk outward")
+	contentOnly := fs.Bool("content", false, "Follow only content edges, ignoring the directory tree")
+	rest, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return fmt.Errorf("usage: grf neighbors <node> [--hops N] [--content]")
+	}
+
+	g, err := cf.load()
+	if err != nil {
+		return err
+	}
+	node, err := g.Resolve(rest[0])
+	if err != nil {
+		return err
+	}
+	found := query.Neighbors(g, node.ID, *hops, *contentOnly)
+
+	if cf.asJSON {
+		return emitJSON(map[string]any{
+			"node":      node,
+			"hops":      *hops,
+			"content":   *contentOnly,
+			"neighbors": found,
+		})
+	}
+
+	// Group by distance so the output reads as rings around the start.
+	sort.SliceStable(found, func(i, j int) bool {
+		if found[i].Hops != found[j].Hops {
+			return found[i].Hops < found[j].Hops
+		}
+		return found[i].Node.ID < found[j].Node.ID
+	})
+
+	w := os.Stdout
+	scope := "all edges"
+	if *contentOnly {
+		scope = "content edges only"
+	}
+	fmt.Fprintf(w, "%s — %d hop(s), %s\n", node.ID, *hops, scope)
+	if len(found) == 0 {
+		fmt.Fprintln(w, "\nnothing reachable")
+		return nil
+	}
+	current := 0
+	for _, nb := range found {
+		if nb.Hops != current {
+			current = nb.Hops
+			fmt.Fprintf(w, "\nhop %d\n", current)
+		}
+		arrow := "-->"
+		if nb.Direction == "in" {
+			arrow = "<--"
+		}
+		fmt.Fprintf(w, "  %s %s  [%s]\n", arrow, nb.Node.ID, nb.Via.Type)
+	}
+	return nil
+}
+
+// ─── path ────────────────────────────────────────────────────────────────────
+
+func cmdPath(args []string) error {
+	fs := flag.NewFlagSet("path", flag.ExitOnError)
+	var cf commonFlags
+	cf.register(fs)
+	rest, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 2 {
+		return fmt.Errorf("usage: grf path <from> <to>")
+	}
+
+	g, err := cf.load()
+	if err != nil {
+		return err
+	}
+	from, err := g.Resolve(rest[0])
+	if err != nil {
+		return err
+	}
+	to, err := g.Resolve(rest[1])
+	if err != nil {
+		return err
+	}
+
+	steps, ok := query.ShortestPath(g, from.ID, to.ID)
+	if cf.asJSON {
+		return emitJSON(map[string]any{
+			"from":      from.ID,
+			"to":        to.ID,
+			"connected": ok,
+			"hops":      len(steps),
+			"steps":     steps,
+		})
+	}
+
+	w := os.Stdout
+	if !ok {
+		fmt.Fprintf(w, "%s and %s are not connected\n", from.ID, to.ID)
+		return nil
+	}
+	fmt.Fprintf(w, "%s → %s (%d hop(s))\n\n", from.ID, to.ID, len(steps))
+	fmt.Fprintf(w, "  %s\n", from.ID)
+	for _, s := range steps {
+		label := s.Edge.Type
+		if s.Edge.Confidence != "" {
+			label += " " + s.Edge.Confidence
+		}
+		if s.Edge.Line > 0 {
+			label += fmt.Sprintf(" L%d", s.Edge.Line)
+		}
+		if s.Forward {
+			fmt.Fprintf(w, "    --[%s]-->  %s\n", label, s.To)
+		} else {
+			fmt.Fprintf(w, "    <--[%s]--  %s\n", label, s.To)
+		}
+	}
+	return nil
+}
+
+func writeHeader(w io.Writer, g *query.Graph) {
+	fmt.Fprintf(w, "%s — %d files, %d folders, %d content edges\n",
+		g.Meta.Root, g.Meta.TotalFiles, g.Meta.TotalFolders, g.Meta.ContentEdges)
+}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -1,0 +1,159 @@
+// Package extract derives content edges — the relationships that live inside
+// files rather than in the directory tree. Structural edges tell you where a
+// file sits; content edges tell you what it actually depends on.
+//
+// Every extractor is pure Go. No cgo, no external parsers: Go files go through
+// go/parser, everything else through a lightweight scan of the source text.
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"grafux/scanner"
+)
+
+// Strategy says how a reference's literal specifier should be turned into a
+// node ID. Extractors pick the strategy; the resolver applies it.
+type Strategy int
+
+const (
+	// RelPath resolves the spec relative to the referencing file's directory.
+	RelPath Strategy = iota
+	// GoPkg resolves a Go import path against the module paths found in go.mod.
+	GoPkg
+	// PyModule resolves a dotted Python module path, honoring leading dots.
+	PyModule
+	// Basename matches the spec against file basenames anywhere in the tree.
+	Basename
+)
+
+// Ref is one unresolved outbound reference found in a file.
+type Ref struct {
+	Spec     string   // the specifier exactly as written in the source
+	Kind     string   // edge type: "import" or "reference"
+	Line     int      // 1-indexed line the reference was found on
+	Strategy Strategy // how to resolve Spec
+	TryExts  []string // extensions to append when Spec has none
+}
+
+// FileContext describes the file an extractor is reading.
+type FileContext struct {
+	ID   string // node ID (slash-separated path relative to root)
+	Name string // base name
+	Dir  string // node ID of the containing directory ("." for root)
+	Root string // absolute path of the scan root
+}
+
+// An Extractor pulls outbound references from one file's contents.
+type Extractor interface {
+	Exts() []string
+	Refs(src []byte, fc FileContext) []Ref
+}
+
+var extractors = []Extractor{
+	goExtractor{},
+	markdownExtractor{},
+	jsExtractor{},
+	pythonExtractor{},
+}
+
+// byExt indexes the registered extractors by lowercase file extension.
+var byExt = func() map[string]Extractor {
+	m := map[string]Extractor{}
+	for _, e := range extractors {
+		for _, ext := range e.Exts() {
+			m[ext] = e
+		}
+	}
+	return m
+}()
+
+// maxFileSize caps how much of a file we will read. Anything larger is almost
+// certainly generated or vendored, and parsing it is not worth the stall.
+const maxFileSize = 2 << 20 // 2 MiB
+
+// Stats reports what a content pass found.
+type Stats struct {
+	FilesRead  int `json:"filesRead"`
+	Refs       int `json:"refs"`
+	Resolved   int `json:"resolved"`
+	Unresolved int `json:"unresolved"`
+	Duplicate  int `json:"duplicate"` // resolved, but the edge already existed
+}
+
+// Run reads every file node the registered extractors understand, resolves the
+// references it finds against the graph, and appends the resulting content
+// edges to g. Duplicate edges collapse into one.
+func Run(g *scanner.Graph) Stats {
+	var st Stats
+	idx := newIndex(g)
+
+	// Existing edges, so a content edge never duplicates a structural one.
+	seen := map[string]bool{}
+	for _, e := range g.Edges {
+		seen[e.Source+"\x00"+e.Target+"\x00"+e.Type] = true
+	}
+
+	for _, n := range g.Nodes {
+		if n.Type != "file" {
+			continue
+		}
+		ex, ok := byExt[strings.ToLower(n.Extension)]
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(n.Path)
+		if err != nil || info.Size() > maxFileSize {
+			continue
+		}
+		src, err := os.ReadFile(n.Path)
+		if err != nil {
+			continue
+		}
+		st.FilesRead++
+
+		fc := FileContext{
+			ID:   n.ID,
+			Name: n.Name,
+			Dir:  parentID(n.ID),
+			Root: g.Meta.Root,
+		}
+
+		for _, ref := range ex.Refs(src, fc) {
+			st.Refs++
+			target, conf, ok := idx.resolve(ref, fc)
+			if !ok || target == n.ID {
+				st.Unresolved++
+				continue
+			}
+			key := n.ID + "\x00" + target + "\x00" + ref.Kind
+			if seen[key] {
+				st.Duplicate++
+				continue
+			}
+			seen[key] = true
+			st.Resolved++
+			g.Edges = append(g.Edges, scanner.Edge{
+				Source:     n.ID,
+				Target:     target,
+				Type:       ref.Kind,
+				Confidence: conf,
+				Line:       ref.Line,
+			})
+		}
+	}
+
+	g.Meta.ContentEdges = st.Resolved
+	return st
+}
+
+// parentID returns the node ID of the directory containing id.
+func parentID(id string) string {
+	d := filepath.ToSlash(filepath.Dir(id))
+	if d == "" {
+		return "."
+	}
+	return d
+}

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -1,0 +1,160 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"grafux/scanner"
+)
+
+// write lays out a temporary project from a path -> contents map.
+func write(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// contentEdges runs a full scan plus extraction and returns "src -> tgt" keys.
+func contentEdges(t *testing.T, root string) map[string]scanner.Edge {
+	t.Helper()
+	g, err := scanner.Scan(root, scanner.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	Run(g)
+	out := map[string]scanner.Edge{}
+	for _, e := range g.Edges {
+		if e.Type != "structural" {
+			out[e.Source+" -> "+e.Target] = e
+		}
+	}
+	return out
+}
+
+func TestGoImportsResolveToPackageDirs(t *testing.T) {
+	root := write(t, map[string]string{
+		"go.mod":        "module example.com/demo\n\ngo 1.21\n",
+		"main.go":       "package main\n\nimport (\n\t\"fmt\"\n\t\"example.com/demo/pkg/auth\"\n)\n\nfunc main() { fmt.Println(auth.X) }\n",
+		"pkg/auth/a.go": "package auth\n\nvar X = 1\n",
+	})
+	edges := contentEdges(t, root)
+
+	e, ok := edges["main.go -> pkg/auth"]
+	if !ok {
+		t.Fatalf("missing edge to package dir; got %v", keys(edges))
+	}
+	if e.Type != "import" || e.Confidence != Extracted {
+		t.Errorf("got type=%q confidence=%q, want import/extracted", e.Type, e.Confidence)
+	}
+	if e.Line != 5 {
+		t.Errorf("got line %d, want 5", e.Line)
+	}
+	// "fmt" is external and must not become an edge.
+	if len(edges) != 1 {
+		t.Errorf("expected only the local import, got %v", keys(edges))
+	}
+}
+
+func TestJSResolutionSkipsCommentsAndPackages(t *testing.T) {
+	root := write(t, map[string]string{
+		"a.ts":        "import x from './lib/util';\n// import dead from './gone';\nimport 'react';\nconst y = require('./lib/util');\n",
+		"lib/util.ts": "export default 1;\n",
+	})
+	edges := contentEdges(t, root)
+
+	if _, ok := edges["a.ts -> lib/util.ts"]; !ok {
+		t.Fatalf("missing relative import; got %v", keys(edges))
+	}
+	if len(edges) != 1 {
+		t.Errorf("commented-out and package imports must not become edges; got %v", keys(edges))
+	}
+}
+
+func TestJSIndexFallback(t *testing.T) {
+	root := write(t, map[string]string{
+		"a.js":         "const m = require('./mod');\n",
+		"mod/index.js": "module.exports = {};\n",
+	})
+	if _, ok := contentEdges(t, root)["a.js -> mod/index.js"]; !ok {
+		t.Fatal("a directory import should resolve to its index file")
+	}
+}
+
+func TestPythonRelativeAndAbsoluteImports(t *testing.T) {
+	root := write(t, map[string]string{
+		"api/handlers/h.py":      "import os\nfrom ..store import cache\nfrom .helper import shape\nimport pkg.policy as p\n",
+		"api/store.py":           "cache = {}\n",
+		"api/handlers/helper.py": "def shape(x): return x\n",
+		"pkg/policy.py":          "ALLOW = True\n",
+	})
+	edges := contentEdges(t, root)
+
+	for _, want := range []string{
+		"api/handlers/h.py -> api/store.py",
+		"api/handlers/h.py -> api/handlers/helper.py",
+		"api/handlers/h.py -> pkg/policy.py",
+	} {
+		if _, ok := edges[want]; !ok {
+			t.Errorf("missing %q; got %v", want, keys(edges))
+		}
+	}
+	if len(edges) != 3 {
+		t.Errorf("stdlib `os` must not become an edge; got %v", keys(edges))
+	}
+}
+
+func TestMarkdownLinksAndFencedCodeIsIgnored(t *testing.T) {
+	root := write(t, map[string]string{
+		"docs/a.md":   "See [[b]] and [code](../src/main.go).\n\n```\n[[never]] and [x](./nope.md)\n```\n[web](https://example.com)\n",
+		"docs/b.md":   "# B\n",
+		"src/main.go": "package main\n",
+	})
+	edges := contentEdges(t, root)
+
+	if e, ok := edges["docs/a.md -> docs/b.md"]; !ok {
+		t.Errorf("wikilink did not resolve; got %v", keys(edges))
+	} else if e.Type != "reference" {
+		t.Errorf("got type %q, want reference", e.Type)
+	}
+	if _, ok := edges["docs/a.md -> src/main.go"]; !ok {
+		t.Errorf("relative markdown link did not resolve; got %v", keys(edges))
+	}
+	if len(edges) != 2 {
+		t.Errorf("fenced code and external URLs must not become edges; got %v", keys(edges))
+	}
+}
+
+func TestAmbiguousWikilinkIsMarkedInferred(t *testing.T) {
+	root := write(t, map[string]string{
+		"a/note.md": "# A\n",
+		"b/note.md": "# B\n",
+		"index.md":  "See [[note]].\n",
+	})
+	edges := contentEdges(t, root)
+	if len(edges) != 1 {
+		t.Fatalf("expected one edge, got %v", keys(edges))
+	}
+	for _, e := range edges {
+		if e.Confidence != Inferred {
+			t.Errorf("a name matching two files should be inferred, got %q", e.Confidence)
+		}
+	}
+}
+
+func keys(m map[string]scanner.Edge) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/extract/golang.go
+++ b/extract/golang.go
@@ -1,0 +1,38 @@
+package extract
+
+import (
+	"go/parser"
+	"go/token"
+	"strconv"
+)
+
+// goExtractor reads imports with the standard library's own parser, so what
+// lands in the graph is exactly what the compiler sees.
+type goExtractor struct{}
+
+func (goExtractor) Exts() []string { return []string{".go"} }
+
+func (goExtractor) Refs(src []byte, fc FileContext) []Ref {
+	fset := token.NewFileSet()
+	// ImportsOnly stops at the import block; a syntax error further down the
+	// file still leaves the imports we care about populated.
+	f, _ := parser.ParseFile(fset, fc.Name, src, parser.ImportsOnly)
+	if f == nil {
+		return nil
+	}
+
+	refs := make([]Ref, 0, len(f.Imports))
+	for _, imp := range f.Imports {
+		spec, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || spec == "" {
+			continue
+		}
+		refs = append(refs, Ref{
+			Spec:     spec,
+			Kind:     "import",
+			Line:     fset.Position(imp.Pos()).Line,
+			Strategy: GoPkg,
+		})
+	}
+	return refs
+}

--- a/extract/jsts.go
+++ b/extract/jsts.go
@@ -1,0 +1,53 @@
+package extract
+
+import "regexp"
+
+// jsExtractor covers the JavaScript/TypeScript family. Only relative
+// specifiers become edges — a bare "react" names a registry package, not a
+// file in this tree.
+type jsExtractor struct{}
+
+func (jsExtractor) Exts() []string {
+	return []string{".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte", ".astro"}
+}
+
+// The four ways a module specifier appears: `from "x"`, `import("x")`,
+// a side-effect `import "x"`, and `require("x")`.
+var jsRefRe = regexp.MustCompile(
+	`\bfrom\s*['"]([^'"\n]+)['"]` +
+		`|\bimport\s*\(\s*['"]([^'"\n]+)['"]` +
+		`|\bimport\s+['"]([^'"\n]+)['"]` +
+		`|\brequire\s*\(\s*['"]([^'"\n]+)['"]`)
+
+// jsTryExts is precedence order for a specifier written without one.
+var jsTryExts = []string{".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue", ".svelte"}
+
+func (jsExtractor) Refs(src []byte, fc FileContext) []Ref {
+	src = stripComments(src)
+	var refs []Ref
+
+	for _, m := range jsRefRe.FindAllSubmatchIndex(src, -1) {
+		spec := firstGroup(src, m)
+		if spec == "" || !isRelativeSpec(spec) {
+			continue
+		}
+		refs = append(refs, Ref{
+			Spec:     spec,
+			Kind:     "import",
+			Line:     lineOf(src, m[0]),
+			Strategy: RelPath,
+			TryExts:  jsTryExts,
+		})
+	}
+	return refs
+}
+
+// firstGroup returns the one alternation branch that actually matched.
+func firstGroup(src []byte, m []int) string {
+	for g := 1; g*2+1 < len(m); g++ {
+		if m[g*2] >= 0 {
+			return string(src[m[g*2]:m[g*2+1]])
+		}
+	}
+	return ""
+}

--- a/extract/markdown.go
+++ b/extract/markdown.go
@@ -1,0 +1,75 @@
+package extract
+
+import (
+	"regexp"
+	"strings"
+)
+
+// markdownExtractor finds the two link forms that connect notes to each other:
+// wiki-style [[links]] and inline [text](relative/path.md).
+type markdownExtractor struct{}
+
+func (markdownExtractor) Exts() []string {
+	return []string{".md", ".mdx", ".markdown"}
+}
+
+var (
+	wikiLinkRe = regexp.MustCompile(`\[\[([^\[\]]+)\]\]`)
+	mdLinkRe   = regexp.MustCompile(`\]\(\s*<?([^)<>\s]+)>?(?:\s+"[^"]*")?\s*\)`)
+	fenceRe    = regexp.MustCompile("(?s)```.*?```|~~~.*?~~~|`[^`\n]*`")
+	schemeRe   = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:|^//`)
+)
+
+func (markdownExtractor) Refs(src []byte, fc FileContext) []Ref {
+	src = blankOut(src, fenceRe)
+	var refs []Ref
+
+	for _, m := range wikiLinkRe.FindAllSubmatchIndex(src, -1) {
+		target := string(src[m[2]:m[3]])
+		// [[note|alias]] and [[note#heading]] both point at "note".
+		if i := strings.IndexAny(target, "|#"); i >= 0 {
+			target = target[:i]
+		}
+		if target = strings.TrimSpace(target); target == "" {
+			continue
+		}
+		refs = append(refs, Ref{
+			Spec:     target,
+			Kind:     "reference",
+			Line:     lineOf(src, m[0]),
+			Strategy: Basename,
+			TryExts:  []string{".md", ".markdown", ".mdx"},
+		})
+	}
+
+	for _, m := range mdLinkRe.FindAllSubmatchIndex(src, -1) {
+		target := string(src[m[2]:m[3]])
+		if target == "" || schemeRe.MatchString(target) || strings.HasPrefix(target, "#") {
+			continue // external URL or same-page anchor
+		}
+		refs = append(refs, Ref{
+			Spec:     target,
+			Kind:     "reference",
+			Line:     lineOf(src, m[0]),
+			Strategy: RelPath,
+			TryExts:  []string{".md", ".markdown", ".mdx"},
+		})
+	}
+
+	return refs
+}
+
+// blankOut replaces every match with spaces, keeping newlines so that byte
+// offsets and line numbers survive.
+func blankOut(src []byte, re *regexp.Regexp) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+	for _, m := range re.FindAllIndex(out, -1) {
+		for i := m[0]; i < m[1]; i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+	return out
+}

--- a/extract/python.go
+++ b/extract/python.go
@@ -1,0 +1,56 @@
+package extract
+
+import (
+	"regexp"
+	"strings"
+)
+
+// pythonExtractor reads import statements. Both regexes anchor to the start of
+// a line, which is also what keeps `# import foo` out of the graph.
+type pythonExtractor struct{}
+
+func (pythonExtractor) Exts() []string { return []string{".py", ".pyi"} }
+
+var (
+	pyFromRe   = regexp.MustCompile(`(?m)^[ \t]*from[ \t]+([.\w]+)[ \t]+import\b`)
+	pyImportRe = regexp.MustCompile(`(?m)^[ \t]*import[ \t]+([^\n#]+)`)
+)
+
+func (pythonExtractor) Refs(src []byte, fc FileContext) []Ref {
+	var refs []Ref
+
+	for _, m := range pyFromRe.FindAllSubmatchIndex(src, -1) {
+		spec := string(src[m[2]:m[3]])
+		if spec == "" {
+			continue
+		}
+		refs = append(refs, Ref{
+			Spec:     spec,
+			Kind:     "import",
+			Line:     lineOf(src, m[0]),
+			Strategy: PyModule,
+		})
+	}
+
+	for _, m := range pyImportRe.FindAllSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		// `import a.b as x, c` — one statement, several modules.
+		for _, part := range strings.Split(string(src[m[2]:m[3]]), ",") {
+			spec := strings.TrimSpace(part)
+			if i := strings.Index(spec, " as "); i >= 0 {
+				spec = strings.TrimSpace(spec[:i])
+			}
+			if spec == "" || strings.ContainsAny(spec, " \t()") {
+				continue
+			}
+			refs = append(refs, Ref{
+				Spec:     spec,
+				Kind:     "import",
+				Line:     line,
+				Strategy: PyModule,
+			})
+		}
+	}
+
+	return refs
+}

--- a/extract/resolve.go
+++ b/extract/resolve.go
@@ -1,0 +1,316 @@
+package extract
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"grafux/scanner"
+)
+
+// Confidence values mirror the distinction the graph makes to its callers:
+// extracted means the source named the target unambiguously, inferred means
+// several candidates matched and the resolver chose one.
+const (
+	Extracted = "extracted"
+	Inferred  = "inferred"
+)
+
+// index is a lookup table over the scanned graph, built once per content pass.
+type index struct {
+	kind    map[string]string   // node ID -> "file" | "folder"
+	byBase  map[string][]string // lowercase basename -> node IDs
+	byStem  map[string][]string // lowercase basename minus extension -> node IDs
+	modules []goModule          // Go modules found in the tree, longest path first
+}
+
+type goModule struct {
+	path string // module path declared in go.mod
+	dir  string // node ID of the directory holding that go.mod
+}
+
+func newIndex(g *scanner.Graph) *index {
+	idx := &index{
+		kind:   make(map[string]string, len(g.Nodes)),
+		byBase: map[string][]string{},
+		byStem: map[string][]string{},
+	}
+	for _, n := range g.Nodes {
+		idx.kind[n.ID] = n.Type
+		if n.Type != "file" {
+			continue
+		}
+		base := strings.ToLower(n.Name)
+		idx.byBase[base] = append(idx.byBase[base], n.ID)
+		stem := strings.TrimSuffix(base, strings.ToLower(n.Extension))
+		idx.byStem[stem] = append(idx.byStem[stem], n.ID)
+		if n.Name == "go.mod" {
+			if mp := readModulePath(n.Path); mp != "" {
+				idx.modules = append(idx.modules, goModule{path: mp, dir: parentID(n.ID)})
+			}
+		}
+	}
+	// Longest module path first, so a nested module wins over its parent.
+	sort.Slice(idx.modules, func(i, j int) bool {
+		return len(idx.modules[i].path) > len(idx.modules[j].path)
+	})
+	return idx
+}
+
+// readModulePath pulls the module path out of a go.mod file.
+func readModulePath(absPath string) string {
+	f, err := os.Open(absPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.Trim(strings.TrimSpace(rest), `"`)
+		}
+	}
+	return ""
+}
+
+// resolve turns a reference into a node ID, reporting how sure it is.
+func (idx *index) resolve(ref Ref, fc FileContext) (string, string, bool) {
+	switch ref.Strategy {
+	case RelPath:
+		return idx.pick(idx.relPathCandidates(ref, fc))
+	case GoPkg:
+		return idx.resolveGoPkg(ref.Spec)
+	case PyModule:
+		return idx.pick(idx.pyCandidates(ref, fc))
+	case Basename:
+		return idx.resolveBasename(ref, fc)
+	}
+	return "", "", false
+}
+
+// pick chooses among the candidates a specifier could name. Files win over
+// directories, so `require("./mod")` lands on mod/index.js rather than on the
+// mod folder; a directory is only the answer when nothing inside it matched.
+// One surviving candidate means the reference named its target, several mean
+// the resolver had to choose.
+func (idx *index) pick(candidates []string) (string, string, bool) {
+	var files, dirs []string
+	for _, c := range candidates {
+		switch idx.kind[c] {
+		case "file":
+			files = append(files, c)
+		case "folder":
+			dirs = append(dirs, c)
+		}
+	}
+	hits := files
+	if len(hits) == 0 {
+		hits = dirs
+	}
+	switch len(hits) {
+	case 0:
+		return "", "", false
+	case 1:
+		return hits[0], Extracted, true
+	default:
+		return hits[0], Inferred, true
+	}
+}
+
+// relPathCandidates expands a filesystem-style specifier into the node IDs it
+// could name, in precedence order: the literal path, then each try extension,
+// then a directory index file.
+func (idx *index) relPathCandidates(ref Ref, fc FileContext) []string {
+	spec := cleanSpec(ref.Spec)
+	if spec == "" {
+		return nil
+	}
+	base := fc.Dir
+	if strings.HasPrefix(spec, "/") {
+		base, spec = ".", strings.TrimPrefix(spec, "/")
+	}
+	joined := path.Join(base, spec)
+	if joined == ".." || strings.HasPrefix(joined, "../") {
+		return nil // escapes the scan root
+	}
+
+	out := []string{joined}
+	for _, ext := range ref.TryExts {
+		out = append(out, joined+ext)
+	}
+	for _, ext := range ref.TryExts {
+		out = append(out, path.Join(joined, "index"+ext))
+	}
+	return out
+}
+
+// pyCandidates maps a dotted module path to the files that could define it.
+// Leading dots are relative-import markers: one dot is the current package,
+// each additional dot climbs one level.
+func (idx *index) pyCandidates(ref Ref, fc FileContext) []string {
+	spec := ref.Spec
+	dots := 0
+	for dots < len(spec) && spec[dots] == '.' {
+		dots++
+	}
+	rest := strings.Trim(spec[dots:], ".")
+	parts := strings.Split(rest, ".")
+	if rest == "" {
+		parts = nil
+	}
+
+	var bases []string
+	if dots == 0 {
+		// Absolute import: could be rooted at the scan root or beside the file.
+		bases = []string{".", fc.Dir}
+	} else {
+		b := fc.Dir
+		for i := 1; i < dots; i++ {
+			b = path.Dir(b)
+			if b == "." || b == "/" {
+				b = "."
+				break
+			}
+		}
+		bases = []string{b}
+	}
+
+	var out []string
+	for _, b := range bases {
+		joined := path.Join(append([]string{b}, parts...)...)
+		if joined == ".." || strings.HasPrefix(joined, "../") {
+			continue
+		}
+		out = append(out, joined+".py", path.Join(joined, "__init__.py"))
+	}
+	return out
+}
+
+// resolveGoPkg maps a Go import path onto a package directory in the tree.
+// Imports that belong to no local module are external and stay unresolved.
+func (idx *index) resolveGoPkg(spec string) (string, string, bool) {
+	for _, m := range idx.modules {
+		var rel string
+		switch {
+		case spec == m.path:
+			rel = ""
+		case strings.HasPrefix(spec, m.path+"/"):
+			rel = strings.TrimPrefix(spec, m.path+"/")
+		default:
+			continue
+		}
+		dir := m.dir
+		if rel != "" {
+			dir = path.Join(m.dir, rel)
+		}
+		if idx.kind[dir] == "folder" {
+			return dir, Extracted, true
+		}
+	}
+	return "", "", false
+}
+
+// resolveBasename backs wiki-style links, which name a note rather than a path.
+func (idx *index) resolveBasename(ref Ref, fc FileContext) (string, string, bool) {
+	spec := cleanSpec(ref.Spec)
+	if spec == "" {
+		return "", "", false
+	}
+	// A wikilink may still carry a path, e.g. [[notes/design]] — try that first.
+	if strings.Contains(spec, "/") {
+		if id, conf, ok := idx.pick(idx.relPathCandidates(Ref{Spec: spec, TryExts: ref.TryExts}, FileContext{Dir: "."})); ok {
+			return id, conf, true
+		}
+		spec = path.Base(spec)
+	}
+
+	key := strings.ToLower(spec)
+	hits := idx.byBase[key]
+	if len(hits) == 0 {
+		hits = idx.byStem[key]
+	}
+	switch len(hits) {
+	case 0:
+		return "", "", false
+	case 1:
+		return hits[0], Extracted, true
+	default:
+		// Ambiguous note name: prefer one in the same folder, else the shallowest.
+		best, bestDepth := "", 1<<30
+		for _, h := range hits {
+			if parentID(h) == fc.Dir {
+				return h, Inferred, true
+			}
+			if d := strings.Count(h, "/"); d < bestDepth {
+				best, bestDepth = h, d
+			}
+		}
+		return best, Inferred, true
+	}
+}
+
+// cleanSpec strips the parts of a link that never name a file: URL fragments,
+// query strings, surrounding quotes, and percent-encoded spaces.
+func cleanSpec(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `"'`)
+	if i := strings.IndexAny(s, "#?"); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.ReplaceAll(s, "%20", " ")
+	return strings.TrimSpace(s)
+}
+
+// isRelativeSpec reports whether a module specifier points inside the project
+// rather than at a package registry.
+func isRelativeSpec(s string) bool {
+	return strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") || s == "." || s == ".."
+}
+
+// stripComments blanks out // and /* */ comments so that a commented-out
+// import never becomes an edge. Bytes are replaced in place, so offsets and
+// line numbers stay accurate.
+func stripComments(src []byte) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+	var inLine, inBlock bool
+	for i := 0; i < len(out); i++ {
+		switch {
+		case inLine:
+			if out[i] == '\n' {
+				inLine = false
+			} else {
+				out[i] = ' '
+			}
+		case inBlock:
+			if out[i] == '*' && i+1 < len(out) && out[i+1] == '/' {
+				out[i], out[i+1] = ' ', ' '
+				i++
+				inBlock = false
+			} else if out[i] != '\n' {
+				out[i] = ' '
+			}
+		case out[i] == '/' && i+1 < len(out) && out[i+1] == '/':
+			out[i], out[i+1] = ' ', ' '
+			i++
+			inLine = true
+		case out[i] == '/' && i+1 < len(out) && out[i+1] == '*':
+			out[i], out[i+1] = ' ', ' '
+			i++
+			inBlock = true
+		}
+	}
+	return out
+}
+
+// lineOf reports the 1-indexed line containing byte offset off.
+func lineOf(src []byte, off int) int {
+	if off > len(src) {
+		off = len(src)
+	}
+	return bytes.Count(src[:off], []byte("\n")) + 1
+}

--- a/main.go
+++ b/main.go
@@ -11,19 +11,31 @@ import (
 	"strings"
 	"syscall"
 
+	"grafux/cli"
 	"grafux/config"
-	"grafux/scanner"
 	"grafux/server"
+	"grafux/store"
 )
 
 func main() {
-	depthFlag      := flag.Int("depth", 5, "Max directory depth (0 = unlimited)")
-	portFlag       := flag.Int("port", 0, "Port to serve on (0 = random available port)")
-	noOpenFlag     := flag.Bool("no-open", false, "Don't auto-open browser")
+	// A verb in the first position means the caller wants data, not a browser.
+	if len(os.Args) > 1 && cli.IsCommand(os.Args[1]) {
+		if err := cli.Run(os.Args[1], os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "grf %s: %v\n", os.Args[1], err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	flag.Usage = usage
+
+	depthFlag := flag.Int("depth", 5, "Max directory depth (0 = unlimited)")
+	portFlag := flag.Int("port", 0, "Port to serve on (0 = random available port)")
+	noOpenFlag := flag.Bool("no-open", false, "Don't auto-open browser")
 	showHiddenFlag := flag.Bool("show-hidden", false, "Include hidden files and folders")
-	themeFlag      := flag.String("theme", "", "UI theme: gruvbox, obsidian, forest, aurora, mono")
-	includeFlag    := flag.String("include", "", "Comma-separated extensions to include (e.g. .go,.md)")
-	excludeFlag    := flag.String("exclude", "", "Comma-separated extensions to exclude (e.g. .log,.tmp)")
+	themeFlag := flag.String("theme", "", "UI theme: gruvbox, obsidian, forest, aurora, mono")
+	includeFlag := flag.String("include", "", "Comma-separated extensions to include (e.g. .go,.md)")
+	excludeFlag := flag.String("exclude", "", "Comma-separated extensions to exclude (e.g. .log,.tmp)")
 	flag.Parse()
 
 	root := "."
@@ -73,14 +85,19 @@ func main() {
 	}
 	cfg.Theme = theme
 
-	graph, scanErr := scanner.Scan(root, scanner.Options{
-		MaxDepth:   depth,
-		ShowHidden: showHidden,
-		Include:    cfg.Include,
-		Exclude:    cfg.Exclude,
-	})
+	cfg.Depth = depth
+	cfg.ShowHidden = showHidden
+
+	graph, stats, scanErr := cli.BuildGraph(root, cfg)
 	if scanErr != nil {
 		log.Fatalf("Scan failed: %v", scanErr)
+	}
+
+	// Leave the graph on disk so `grf query` and any agent can read it without
+	// this server running.
+	savedTo, saveErr := store.Save(root, graph)
+	if saveErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not save graph: %v\n", saveErr)
 	}
 
 	addr, tabClosed, startErr := server.Start(port, graph, cfg)
@@ -90,8 +107,11 @@ func main() {
 
 	url := fmt.Sprintf("http://%s", addr)
 	fmt.Printf("Grafux: %s\n", url)
-	fmt.Printf("  %d files · %d folders · depth %d · theme: %s\n",
-		graph.Meta.TotalFiles, graph.Meta.TotalFolders, depth, cfg.Theme)
+	fmt.Printf("  %d files · %d folders · %d content edges · depth %d · theme: %s\n",
+		graph.Meta.TotalFiles, graph.Meta.TotalFolders, stats.Resolved, depth, cfg.Theme)
+	if savedTo != "" {
+		fmt.Printf("  graph saved to %s\n", savedTo)
+	}
 	fmt.Println("  Press Ctrl+C to stop")
 
 	if !noOpen {
@@ -106,6 +126,20 @@ func main() {
 	case <-tabClosed:
 		fmt.Println("\nBrowser tab closed. Stopped.")
 	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `grf — visualize and query a directory as a graph.
+
+Usage:
+  grf [flags] [path]           Scan a directory and open the graph in a browser
+  grf <command> [args]         Read the graph without a browser
+
+%s
+
+Flags:
+`, cli.Usage())
+	flag.PrintDefaults()
 }
 
 func splitExts(s string) []string {

--- a/query/query.go
+++ b/query/query.go
@@ -1,0 +1,423 @@
+// Package query answers questions about a scanned graph: find a node, list
+// what it touches, and trace how two nodes connect. It is the read surface
+// that the CLI and any agent driving it share.
+package query
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"grafux/scanner"
+)
+
+// Graph wraps a scanned graph with the indexes traversal needs.
+type Graph struct {
+	*scanner.Graph
+	byID map[string]int   // node ID -> index into Nodes
+	out  map[string][]int // node ID -> indices into Edges, as source
+	in   map[string][]int // node ID -> indices into Edges, as target
+}
+
+// New builds the lookup indexes. Cost is linear in the size of the graph.
+func New(g *scanner.Graph) *Graph {
+	q := &Graph{
+		Graph: g,
+		byID:  make(map[string]int, len(g.Nodes)),
+		out:   make(map[string][]int),
+		in:    make(map[string][]int),
+	}
+	for i, n := range g.Nodes {
+		q.byID[n.ID] = i
+	}
+	for i, e := range g.Edges {
+		q.out[e.Source] = append(q.out[e.Source], i)
+		q.in[e.Target] = append(q.in[e.Target], i)
+	}
+	return q
+}
+
+// Node looks up a node by exact ID.
+func (g *Graph) Node(id string) (scanner.Node, bool) {
+	i, ok := g.byID[id]
+	if !ok {
+		return scanner.Node{}, false
+	}
+	return g.Nodes[i], true
+}
+
+// Degree counts every edge touching a node, in either direction.
+func (g *Graph) Degree(id string) int {
+	return len(g.out[id]) + len(g.in[id])
+}
+
+// IsContent reports whether an edge came from a file's contents rather than
+// from the directory tree.
+func IsContent(e scanner.Edge) bool { return e.Type != "structural" }
+
+// ─── Resolving a user-supplied reference ─────────────────────────────────────
+
+// AmbiguousError reports a reference that matched several nodes. It lists them
+// so the caller can pick one instead of guessing.
+type AmbiguousError struct {
+	Ref        string
+	Candidates []string
+}
+
+func (e *AmbiguousError) Error() string {
+	return fmt.Sprintf("%q matches %d nodes: %s", e.Ref, len(e.Candidates), strings.Join(e.Candidates, ", "))
+}
+
+// NotFoundError reports a reference that matched nothing, with the nearest
+// misses attached so the caller has somewhere to go next.
+type NotFoundError struct {
+	Ref     string
+	Nearest []string
+}
+
+func (e *NotFoundError) Error() string {
+	if len(e.Nearest) == 0 {
+		return fmt.Sprintf("no node matches %q", e.Ref)
+	}
+	return fmt.Sprintf("no node matches %q; did you mean: %s", e.Ref, strings.Join(e.Nearest, ", "))
+}
+
+// Resolve turns a human- or agent-supplied reference into exactly one node.
+// It tries progressively looser matches: exact ID, path suffix, base name,
+// then a ranked search.
+func (g *Graph) Resolve(ref string) (scanner.Node, error) {
+	ref = strings.TrimSpace(strings.Trim(ref, `"'`))
+	ref = strings.TrimPrefix(ref, "./")
+	if ref == "" {
+		return scanner.Node{}, &NotFoundError{Ref: ref}
+	}
+
+	if n, ok := g.Node(ref); ok {
+		return n, nil
+	}
+
+	lower := strings.ToLower(ref)
+	var suffix, base []scanner.Node
+	for _, n := range g.Nodes {
+		id := strings.ToLower(n.ID)
+		if strings.HasSuffix(id, "/"+lower) {
+			suffix = append(suffix, n)
+		}
+		if strings.ToLower(n.Name) == lower {
+			base = append(base, n)
+		}
+	}
+	for _, set := range [][]scanner.Node{suffix, base} {
+		switch len(set) {
+		case 1:
+			return set[0], nil
+		case 0:
+			continue
+		default:
+			return scanner.Node{}, &AmbiguousError{Ref: ref, Candidates: ids(set)}
+		}
+	}
+
+	// Fall back to search. A clear winner is good enough to act on.
+	matches := Search(g, ref, 5)
+	if len(matches) == 0 {
+		return scanner.Node{}, &NotFoundError{Ref: ref}
+	}
+	if len(matches) == 1 || matches[0].Score > matches[1].Score*2 {
+		return matches[0].Node, nil
+	}
+	return scanner.Node{}, &AmbiguousError{Ref: ref, Candidates: matchIDs(matches)}
+}
+
+func ids(ns []scanner.Node) []string {
+	out := make([]string, len(ns))
+	for i, n := range ns {
+		out[i] = n.ID
+	}
+	return out
+}
+
+func matchIDs(ms []Match) []string {
+	out := make([]string, len(ms))
+	for i, m := range ms {
+		out[i] = m.Node.ID
+	}
+	return out
+}
+
+// ─── Search ──────────────────────────────────────────────────────────────────
+
+// Match is one search hit.
+type Match struct {
+	Node   scanner.Node `json:"node"`
+	Score  int          `json:"score"`
+	Degree int          `json:"degree"`
+}
+
+// Search ranks nodes against a free-text query. Every whitespace-separated
+// term must match somewhere, so more words narrow the result rather than
+// widening it.
+func Search(g *Graph, q string, limit int) []Match {
+	terms := strings.Fields(strings.ToLower(q))
+	if len(terms) == 0 {
+		return nil
+	}
+
+	var out []Match
+	for _, n := range g.Nodes {
+		total := 0
+		for _, t := range terms {
+			s := scoreNode(n, t)
+			if s == 0 {
+				total = 0
+				break
+			}
+			total += s
+		}
+		if total == 0 {
+			continue
+		}
+		deg := g.Degree(n.ID)
+		// A well-connected node is more likely to be the one being asked about,
+		// but connectivity must not outrank a direct name match.
+		if deg > 20 {
+			deg = 20
+		}
+		out = append(out, Match{Node: n, Score: total + deg, Degree: g.Degree(n.ID)})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if len(out[i].Node.ID) != len(out[j].Node.ID) {
+			return len(out[i].Node.ID) < len(out[j].Node.ID)
+		}
+		return out[i].Node.ID < out[j].Node.ID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func scoreNode(n scanner.Node, term string) int {
+	id := strings.ToLower(n.ID)
+	name := strings.ToLower(n.Name)
+	ext := strings.ToLower(n.Extension)
+	stem := strings.TrimSuffix(name, ext)
+
+	switch {
+	case id == term:
+		return 1000
+	case name == term, stem == term:
+		return 900
+	case ext != "" && ext == term:
+		return 800
+	case strings.HasPrefix(name, term):
+		return 700
+	case strings.Contains(name, term):
+		return 500
+	case strings.Contains(id, term):
+		return 300
+	case isSubsequence(name, term):
+		return 120
+	case isSubsequence(id, term):
+		return 60
+	}
+	return 0
+}
+
+// isSubsequence reports whether every character of needle appears in haystack
+// in order — the loose matching a fuzzy finder does.
+func isSubsequence(haystack, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	i := 0
+	for j := 0; j < len(haystack) && i < len(needle); j++ {
+		if haystack[j] == needle[i] {
+			i++
+		}
+	}
+	return i == len(needle)
+}
+
+// ─── Traversal ───────────────────────────────────────────────────────────────
+
+// Neighbor is a node reached from a starting point, with the edge that got
+// there.
+type Neighbor struct {
+	Node      scanner.Node `json:"node"`
+	Hops      int          `json:"hops"`
+	Via       scanner.Edge `json:"via"`
+	Direction string       `json:"direction"` // "out" if the edge points away, "in" if toward
+}
+
+// Neighbors walks outward from a node up to hops away. Passing contentOnly
+// skips the directory tree, which is what makes the result a dependency
+// neighborhood rather than a folder listing.
+func Neighbors(g *Graph, id string, hops int, contentOnly bool) []Neighbor {
+	if hops < 1 {
+		hops = 1
+	}
+	seen := map[string]bool{id: true}
+	var out []Neighbor
+	frontier := []string{id}
+
+	for h := 1; h <= hops && len(frontier) > 0; h++ {
+		var next []string
+		for _, cur := range frontier {
+			visit := func(edgeIdx []int, dir string) {
+				for _, ei := range edgeIdx {
+					e := g.Edges[ei]
+					if contentOnly && !IsContent(e) {
+						continue
+					}
+					other := e.Target
+					if dir == "in" {
+						other = e.Source
+					}
+					if seen[other] {
+						continue
+					}
+					n, ok := g.Node(other)
+					if !ok {
+						continue
+					}
+					seen[other] = true
+					out = append(out, Neighbor{Node: n, Hops: h, Via: e, Direction: dir})
+					next = append(next, other)
+				}
+			}
+			visit(g.out[cur], "out")
+			visit(g.in[cur], "in")
+		}
+		frontier = next
+	}
+	return out
+}
+
+// Step is one hop along a path. Forward reports whether the edge was traversed
+// in its own direction or against it.
+type Step struct {
+	From    string       `json:"from"`
+	To      string       `json:"to"`
+	Edge    scanner.Edge `json:"edge"`
+	Forward bool         `json:"forward"`
+}
+
+// ShortestPath finds the fewest hops between two nodes, treating edges as
+// undirected — how two files relate matters more than which one pointed first.
+func ShortestPath(g *Graph, from, to string) ([]Step, bool) {
+	if from == to {
+		return nil, true
+	}
+	type crumb struct {
+		prev    string
+		edge    scanner.Edge
+		forward bool
+	}
+	trail := map[string]crumb{from: {}}
+	queue := []string{from}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		step := func(edgeIdx []int, forward bool) bool {
+			for _, ei := range edgeIdx {
+				e := g.Edges[ei]
+				other := e.Target
+				if !forward {
+					other = e.Source
+				}
+				if _, ok := trail[other]; ok {
+					continue
+				}
+				trail[other] = crumb{prev: cur, edge: e, forward: forward}
+				if other == to {
+					return true
+				}
+				queue = append(queue, other)
+			}
+			return false
+		}
+		if step(g.out[cur], true) || step(g.in[cur], false) {
+			break
+		}
+	}
+
+	if _, ok := trail[to]; !ok {
+		return nil, false
+	}
+
+	var steps []Step
+	for cur := to; cur != from; {
+		c := trail[cur]
+		steps = append(steps, Step{From: c.prev, To: cur, Edge: c.edge, Forward: c.forward})
+		cur = c.prev
+	}
+	// Built backwards from the destination.
+	for i, j := 0, len(steps)-1; i < j; i, j = i+1, j-1 {
+		steps[i], steps[j] = steps[j], steps[i]
+	}
+	return steps, true
+}
+
+// ─── Explain ─────────────────────────────────────────────────────────────────
+
+// Link is one connection listed in an explanation.
+type Link struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Confidence string `json:"confidence,omitempty"`
+	Line       int    `json:"line,omitempty"`
+}
+
+// Explanation is everything the graph knows about a single node.
+type Explanation struct {
+	Node       scanner.Node `json:"node"`
+	Degree     int          `json:"degree"`
+	Parent     string       `json:"parent,omitempty"`
+	Children   []Link       `json:"children,omitempty"`
+	DependsOn  []Link       `json:"dependsOn,omitempty"`
+	DependedOn []Link       `json:"dependedOnBy,omitempty"`
+}
+
+// Explain gathers a node's structural position and its content relationships.
+func Explain(g *Graph, id string) (Explanation, bool) {
+	n, ok := g.Node(id)
+	if !ok {
+		return Explanation{}, false
+	}
+	ex := Explanation{Node: n, Degree: g.Degree(id)}
+
+	for _, ei := range g.out[id] {
+		e := g.Edges[ei]
+		l := Link{ID: e.Target, Type: e.Type, Confidence: e.Confidence, Line: e.Line}
+		if IsContent(e) {
+			ex.DependsOn = append(ex.DependsOn, l)
+		} else {
+			ex.Children = append(ex.Children, l)
+		}
+	}
+	for _, ei := range g.in[id] {
+		e := g.Edges[ei]
+		l := Link{ID: e.Source, Type: e.Type, Confidence: e.Confidence, Line: e.Line}
+		if IsContent(e) {
+			ex.DependedOn = append(ex.DependedOn, l)
+		} else if ex.Parent == "" {
+			ex.Parent = e.Source
+		}
+	}
+
+	sortLinks(ex.Children)
+	sortLinks(ex.DependsOn)
+	sortLinks(ex.DependedOn)
+	return ex, true
+}
+
+func sortLinks(ls []Link) {
+	sort.Slice(ls, func(i, j int) bool { return ls[i].ID < ls[j].ID })
+}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1,0 +1,149 @@
+package query
+
+import (
+	"errors"
+	"testing"
+
+	"grafux/scanner"
+)
+
+// testGraph is a small project: two markdown notes linking to each other and a
+// Go file that main.go imports through its package folder.
+func testGraph() *Graph {
+	g := &scanner.Graph{
+		Nodes: []scanner.Node{
+			{ID: ".", Name: "proj", Type: "folder"},
+			{ID: "main.go", Name: "main.go", Type: "file", Extension: ".go"},
+			{ID: "auth", Name: "auth", Type: "folder"},
+			{ID: "auth/token.go", Name: "token.go", Type: "file", Extension: ".go"},
+			{ID: "docs", Name: "docs", Type: "folder"},
+			{ID: "docs/design.md", Name: "design.md", Type: "file", Extension: ".md"},
+			{ID: "notes/design.md", Name: "design.md", Type: "file", Extension: ".md"},
+		},
+		Edges: []scanner.Edge{
+			{Source: ".", Target: "main.go", Type: "structural"},
+			{Source: ".", Target: "auth", Type: "structural"},
+			{Source: "auth", Target: "auth/token.go", Type: "structural"},
+			{Source: ".", Target: "docs", Type: "structural"},
+			{Source: "docs", Target: "docs/design.md", Type: "structural"},
+			{Source: "main.go", Target: "auth", Type: "import", Confidence: "extracted", Line: 5},
+			{Source: "docs/design.md", Target: "main.go", Type: "reference", Confidence: "extracted", Line: 3},
+		},
+	}
+	return New(g)
+}
+
+func TestResolveExactAndSuffix(t *testing.T) {
+	g := testGraph()
+
+	if n, err := g.Resolve("auth/token.go"); err != nil || n.ID != "auth/token.go" {
+		t.Errorf("exact ID: got %q, %v", n.ID, err)
+	}
+	if n, err := g.Resolve("token.go"); err != nil || n.ID != "auth/token.go" {
+		t.Errorf("base name: got %q, %v", n.ID, err)
+	}
+	if n, err := g.Resolve("./main.go"); err != nil || n.ID != "main.go" {
+		t.Errorf("leading ./ should be tolerated: got %q, %v", n.ID, err)
+	}
+}
+
+func TestResolveAmbiguousListsCandidates(t *testing.T) {
+	g := testGraph()
+
+	_, err := g.Resolve("design.md")
+	var amb *AmbiguousError
+	if !errors.As(err, &amb) {
+		t.Fatalf("want AmbiguousError, got %v", err)
+	}
+	if len(amb.Candidates) != 2 {
+		t.Errorf("want both notes listed, got %v", amb.Candidates)
+	}
+	// The full path disambiguates.
+	if n, err := g.Resolve("docs/design.md"); err != nil || n.ID != "docs/design.md" {
+		t.Errorf("full path: got %q, %v", n.ID, err)
+	}
+}
+
+func TestResolveNotFound(t *testing.T) {
+	g := testGraph()
+	if _, err := g.Resolve("nothing-like-this-exists"); err == nil {
+		t.Fatal("want an error for an unmatched reference")
+	}
+}
+
+func TestShortestPathTraversesEdgesInEitherDirection(t *testing.T) {
+	g := testGraph()
+
+	steps, ok := ShortestPath(g, "docs/design.md", "auth/token.go")
+	if !ok {
+		t.Fatal("nodes should be connected")
+	}
+	// design.md -> main.go -> auth -> auth/token.go
+	if len(steps) != 3 {
+		t.Fatalf("want 3 hops, got %d: %+v", len(steps), steps)
+	}
+	if steps[0].To != "main.go" || steps[1].To != "auth" || steps[2].To != "auth/token.go" {
+		t.Errorf("unexpected route: %+v", steps)
+	}
+	if !steps[0].Forward {
+		t.Error("the reference edge points from the note to main.go")
+	}
+}
+
+func TestShortestPathReportsDisconnected(t *testing.T) {
+	g := testGraph()
+	if _, ok := ShortestPath(g, "main.go", "notes/design.md"); ok {
+		t.Error("an unlinked node should not be reachable")
+	}
+}
+
+func TestNeighborsContentOnlySkipsTheDirectoryTree(t *testing.T) {
+	g := testGraph()
+
+	all := Neighbors(g, "main.go", 1, false)
+	content := Neighbors(g, "main.go", 1, true)
+
+	if len(all) <= len(content) {
+		t.Errorf("structural edges should add neighbors: all=%d content=%d", len(all), len(content))
+	}
+	for _, n := range content {
+		if !IsContent(n.Via) {
+			t.Errorf("content-only walk returned a %q edge", n.Via.Type)
+		}
+	}
+	if len(content) != 2 {
+		t.Errorf("want the import out and the reference in, got %d", len(content))
+	}
+}
+
+func TestExplainSeparatesStructureFromDependencies(t *testing.T) {
+	g := testGraph()
+
+	ex, ok := Explain(g, "main.go")
+	if !ok {
+		t.Fatal("main.go should exist")
+	}
+	if ex.Parent != "." {
+		t.Errorf("want parent '.', got %q", ex.Parent)
+	}
+	if len(ex.DependsOn) != 1 || ex.DependsOn[0].ID != "auth" {
+		t.Errorf("want one dependency on auth, got %+v", ex.DependsOn)
+	}
+	if len(ex.DependedOn) != 1 || ex.DependedOn[0].ID != "docs/design.md" {
+		t.Errorf("want the doc reference back, got %+v", ex.DependedOn)
+	}
+}
+
+func TestSearchRequiresEveryTerm(t *testing.T) {
+	g := testGraph()
+
+	if got := Search(g, "token", 10); len(got) == 0 || got[0].Node.ID != "auth/token.go" {
+		t.Errorf("single term: got %+v", got)
+	}
+	if got := Search(g, "auth token", 10); len(got) != 1 || got[0].Node.ID != "auth/token.go" {
+		t.Errorf("both terms must match the same node: got %+v", got)
+	}
+	if got := Search(g, "token nonexistentterm", 10); len(got) != 0 {
+		t.Errorf("an unmatched term should eliminate the node: got %+v", got)
+	}
+}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -18,10 +18,16 @@ type Node struct {
 	Size      int64  `json:"size,omitempty"`
 }
 
+// Edge connects two nodes. Type is "structural" for the directory tree, or
+// "import"/"reference" for a relationship read out of a file's contents.
+// Confidence records whether the source named its target unambiguously
+// ("extracted") or the resolver had to choose between candidates ("inferred").
 type Edge struct {
-	Source string `json:"source"`
-	Target string `json:"target"`
-	Type   string `json:"type"`
+	Source     string `json:"source"`
+	Target     string `json:"target"`
+	Type       string `json:"type"`
+	Confidence string `json:"confidence,omitempty"`
+	Line       int    `json:"line,omitempty"`
 }
 
 type Meta struct {
@@ -29,6 +35,7 @@ type Meta struct {
 	TotalFiles   int       `json:"totalFiles"`
 	TotalFolders int       `json:"totalFolders"`
 	ScanDepth    int       `json:"scanDepth"`
+	ContentEdges int       `json:"contentEdges"`
 	ScannedAt    time.Time `json:"scannedAt"`
 }
 
@@ -47,6 +54,7 @@ type Options struct {
 
 var defaultIgnore = map[string]bool{
 	".git":          true,
+	".grafux":       true,
 	"node_modules":  true,
 	"__pycache__":   true,
 	".DS_Store":     true,

--- a/server/web/graph.js
+++ b/server/web/graph.js
@@ -10,6 +10,7 @@ const THEMES = {
     edge:          'rgba(146,131,116,0.25)',
     edgeHover:     'rgba(235,219,178,0.75)',
     edgeDim:       'rgba(146,131,116,0.05)',
+    contentEdge:   'rgba(131,165,152,0.55)',
     hoverRing:     'rgba(250,189,47,0.5)',
     label:         'rgba(235,219,178,1)',
     labelNeighbor: 'rgba(235,219,178,0.65)',
@@ -23,6 +24,7 @@ const THEMES = {
     edge:          'rgba(255,255,255,0.18)',
     edgeHover:     'rgba(255,255,255,0.65)',
     edgeDim:       'rgba(255,255,255,0.05)',
+    contentEdge:   'rgba(122,162,247,0.5)',
     hoverRing:     'rgba(255,255,255,0.55)',
     label:         'rgba(255,255,255,1)',
     labelNeighbor: 'rgba(255,255,255,0.6)',
@@ -36,6 +38,7 @@ const THEMES = {
     edge:          'rgba(149,213,178,0.2)',
     edgeHover:     'rgba(149,213,178,0.7)',
     edgeDim:       'rgba(149,213,178,0.04)',
+    contentEdge:   'rgba(244,211,94,0.5)',
     hoverRing:     'rgba(149,213,178,0.6)',
     label:         'rgba(210,240,220,1)',
     labelNeighbor: 'rgba(210,240,220,0.65)',
@@ -49,6 +52,7 @@ const THEMES = {
     edge:          'rgba(196,181,253,0.18)',
     edgeHover:     'rgba(196,181,253,0.7)',
     edgeDim:       'rgba(196,181,253,0.04)',
+    contentEdge:   'rgba(244,114,182,0.5)',
     hoverRing:     'rgba(196,181,253,0.6)',
     label:         'rgba(230,225,255,1)',
     labelNeighbor: 'rgba(230,225,255,0.65)',
@@ -62,6 +66,7 @@ const THEMES = {
     edge:          'rgba(255,255,255,0.14)',
     edgeHover:     'rgba(255,255,255,0.6)',
     edgeDim:       'rgba(255,255,255,0.03)',
+    contentEdge:   'rgba(255,255,255,0.42)',
     hoverRing:     'rgba(255,255,255,0.5)',
     label:         'rgba(255,255,255,1)',
     labelNeighbor: 'rgba(255,255,255,0.55)',
@@ -203,6 +208,7 @@ function isConnected(a, b) {
 
 // ─── Spanning Tree (Kruskal's) ────────────────────────────────────────────────
 let spanningTreeEdges = null; // Set of "srcId|tgtId" keys when active
+let showContentEdges = true;  // content edges are on by default
 
 function computeSpanningTree() {
   // Union-Find
@@ -235,6 +241,17 @@ function computeSpanningTree() {
     }
   }
   return treeEdges;
+}
+
+// Content edges come from inside files (imports, links); structural edges are
+// the directory tree. They are drawn differently because they mean different
+// things.
+function isContentEdge(e) {
+  return e.type !== undefined && e.type !== 'structural';
+}
+
+function skipEdge(e) {
+  return !showContentEdges && isContentEdge(e);
 }
 
 function isSpanningTreeEdge(e) {
@@ -518,6 +535,7 @@ function render() {
     for (const e of graphData.edges) {
       const src = e.source, tgt = e.target;
       if (src.x === undefined || tgt.x === undefined) continue;
+      if (skipEdge(e)) continue;
       if (!edgeInView(src.x, src.y, tgt.x, tgt.y)) continue;
       if (src === hoveredNode || tgt === hoveredNode) continue;
       ctx.moveTo(src.x, src.y);
@@ -531,6 +549,7 @@ function render() {
     for (const e of graphData.edges) {
       const src = e.source, tgt = e.target;
       if (src.x === undefined || tgt.x === undefined) continue;
+      if (skipEdge(e)) continue;
       if (src !== hoveredNode && tgt !== hoveredNode) continue;
       ctx.moveTo(src.x, src.y);
       ctx.lineTo(tgt.x, tgt.y);
@@ -544,6 +563,7 @@ function render() {
     for (const e of graphData.edges) {
       const src = e.source, tgt = e.target;
       if (src.x === undefined || tgt.x === undefined) continue;
+      if (skipEdge(e)) continue;
       if (!edgeInView(src.x, src.y, tgt.x, tgt.y)) continue;
       if (isSpanningTreeEdge(e)) continue;
       ctx.moveTo(src.x, src.y);
@@ -565,18 +585,35 @@ function render() {
     }
     ctx.stroke();
   } else {
-    // Single batch — all edges same style
+    // Structural edges — the directory tree, drawn quietly underneath.
     ctx.beginPath();
     ctx.strokeStyle = activeTheme.edge;
     ctx.lineWidth = (0.8 * ew) / k;
     for (const e of graphData.edges) {
       const src = e.source, tgt = e.target;
       if (src.x === undefined || tgt.x === undefined) continue;
+      if (isContentEdge(e)) continue;
       if (!edgeInView(src.x, src.y, tgt.x, tgt.y)) continue;
       ctx.moveTo(src.x, src.y);
       ctx.lineTo(tgt.x, tgt.y);
     }
     ctx.stroke();
+
+    // Content edges — imports and links read out of the files themselves.
+    if (showContentEdges) {
+      ctx.beginPath();
+      ctx.strokeStyle = activeTheme.contentEdge || activeTheme.edgeHover;
+      ctx.lineWidth = (1.3 * ew) / k;
+      for (const e of graphData.edges) {
+        const src = e.source, tgt = e.target;
+        if (src.x === undefined || tgt.x === undefined) continue;
+        if (!isContentEdge(e)) continue;
+        if (!edgeInView(src.x, src.y, tgt.x, tgt.y)) continue;
+        ctx.moveTo(src.x, src.y);
+        ctx.lineTo(tgt.x, tgt.y);
+      }
+      ctx.stroke();
+    }
   }
 
   // ── Nodes ──────────────────────────────────────────────────────────────────
@@ -797,6 +834,15 @@ function setupSettingsPanel() {
     pill.addEventListener('click', () => applyLayout(pill.dataset.layout));
   });
 
+  // Content edge checkbox
+  const ceCheck = document.getElementById('content-edge-toggle');
+  if (ceCheck) {
+    ceCheck.addEventListener('change', () => {
+      showContentEdges = ceCheck.checked;
+      scheduleRender();
+    });
+  }
+
   // Spanning tree checkbox
   const stCheck = document.getElementById('spanning-tree-toggle');
   if (stCheck) {
@@ -856,7 +902,8 @@ async function init() {
 
     const m = graphData.meta || {};
     const depthStr = m.scanDepth > 0 ? `depth ${m.scanDepth}` : 'unlimited depth';
-    statsEl.textContent = `${m.totalFiles || 0} files · ${m.totalFolders || 0} folders · ${depthStr}`;
+    const contentStr = m.contentEdges ? ` · ${m.contentEdges} links` : '';
+    statsEl.textContent = `${m.totalFiles || 0} files · ${m.totalFolders || 0} folders${contentStr} · ${depthStr}`;
 
     setupSimulation();
     setupInteractions();

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -36,6 +36,10 @@
         <button class="layout-pill" data-layout="tree">Tree</button>
       </div>
       <label class="settings-check">
+        <input type="checkbox" id="content-edge-toggle" checked>
+        <span>Content edges</span>
+      </label>
+      <label class="settings-check">
         <input type="checkbox" id="spanning-tree-toggle">
         <span>Spanning tree</span>
       </label>

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,97 @@
+// Package store persists a scanned graph to disk so that anything which is not
+// a browser — an agent, a script, another grafux command — can read it without
+// a running server.
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"grafux/scanner"
+)
+
+// Dir is the per-project directory holding grafux's artifacts.
+const Dir = ".grafux"
+
+// FileName is the graph artifact inside Dir.
+const FileName = "graph.json"
+
+// Path returns where the graph artifact lives for a given project root.
+func Path(root string) string {
+	return filepath.Join(root, Dir, FileName)
+}
+
+// Save writes the graph atomically and returns the path it wrote to.
+func Save(root string, g *scanner.Graph) (string, error) {
+	dir := filepath.Join(root, Dir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create %s: %w", dir, err)
+	}
+
+	data, err := json.MarshalIndent(g, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal graph: %w", err)
+	}
+
+	dest := filepath.Join(dir, FileName)
+	tmp, err := os.CreateTemp(dir, FileName+".tmp*")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("write graph: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close graph: %w", err)
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		return "", fmt.Errorf("replace %s: %w", dest, err)
+	}
+	return dest, nil
+}
+
+// Load reads a graph artifact from an explicit path.
+func Load(path string) (*scanner.Graph, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var g scanner.Graph
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(g.Nodes) == 0 {
+		return nil, fmt.Errorf("%s contains no nodes", path)
+	}
+	return &g, nil
+}
+
+// ErrNotFound reports that no graph artifact exists in or above a directory.
+var ErrNotFound = errors.New("no .grafux/graph.json found")
+
+// Find walks up from start looking for a graph artifact, the way git looks for
+// .git. It returns the path to the artifact and the project root holding it.
+func Find(start string) (graphPath, root string, err error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", "", err
+	}
+	for {
+		candidate := filepath.Join(dir, Dir, FileName)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", "", ErrNotFound
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Why

The scanner only produced `parent -> child` edges, so the graph showed where files sit but not how they relate — which is roughly what `ls -R` already tells you. And the graph only ever existed in memory, served on a random port, for as long as a browser tab stayed open.

This makes the graph mean something, and makes it readable without a browser.

## Content edges

A new `extract` pass reads relationships out of file contents:

| Language | Extensions | How |
| --- | --- | --- |
| Go | `.go` | `go/parser`, resolved through `go.mod` to package directories |
| JS / TS | `.js .jsx .mjs .cjs .ts .tsx .mts .cts .vue .svelte .astro` | `from`, `require()`, dynamic `import()`, `export…from` — relative specifiers only |
| Python | `.py .pyi` | absolute and relative dotted imports |
| Markdown | `.md .mdx .markdown` | `[[wikilinks]]` and `[text](relative/path)` |

Every parser is pure Go — no cgo, so cross-compilation stays a plain `GOOS=… go build`.

Only references that resolve to a node inside the scan become edges. Third-party packages, external URLs, fenced code blocks and commented-out imports are all dropped. Each edge records a confidence — `extracted` when the source named its target unambiguously, `inferred` when several candidates matched and the resolver picked one — plus the line it was found on.

Adding a language means implementing `extract.Extractor` and registering it in the `extractors` slice.

## Query surface

Every run now writes `.grafux/graph.json`. Five commands read it with no server and no browser:

```bash
grf scan [path]                    # scan and save
grf query auth token               # rank nodes; every term must match
grf explain scanner/scanner.go     # a node, its parent, every link in and out
grf neighbors main.go --content    # walk outward, skipping the folder tree
grf path docs/design.md policy.py  # shortest connection, edges undirected
```

All take `--json`. They locate the artifact by walking up from the working directory the way git finds `.git`, and fall back to scanning the cwd if there is none. Node arguments resolve loosely — exact ID, then path suffix, then base name, then ranked search — and an ambiguous name returns the candidate list rather than guessing.

The point is that an agent can answer *"does changing A affect B?"* in one call instead of a Read plus several greps.

## Frontend

Content edges render in a distinct per-theme color above the structural tree, with a settings-panel toggle to isolate them. The stats line reports the link count.

## Compatibility

Bare `grf` and `grf ./path` are unchanged. Dispatch only happens when the first argument matches a known verb.

## Test plan

- `go test ./...` — 13 tests across `extract` and `query`, covering per-language resolution, the extracted/inferred distinction, fenced-code and comment exclusion, directory-vs-index-file precedence, fuzzy resolution, ambiguity reporting, and BFS pathfinding.
- Verified by hand against a multi-language fixture (Go + TS + Python + markdown, cross-linked): 14 of 14 resolvable references became correct edges, with only stdlib imports left unresolved.
- Verified in the browser: 15 content edges render distinctly, and the toggle hides exactly those 15.

## Not in scope

The graph is file-level, not symbol-level — a Go import resolves to the package directory, which is what the import actually names, so a file's dependents show up one hop away through the folder node. Symbol nodes, an MCP server, token-budgeted context packs, and hub/community detection are on the v0.3 roadmap.